### PR TITLE
Update max_open_trades to 5 in Binance config example

### DIFF
--- a/config_examples/config_binance.example.json
+++ b/config_examples/config_binance.example.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://schema.freqtrade.io/schema.json",
-    "max_open_trades": 3,
+    "max_open_trades": 5,
     "stake_currency": "USDT",
     "stake_amount": 0.05,
     "tradable_balance_ratio": 0.99,


### PR DESCRIPTION
## Summary

This PR updates the `max_open_trades` configuration value from 3 to 5 in the Binance example configuration file.

## Changes

- Modified `config_examples/config_binance.example.json`
- Changed `max_open_trades` from `3` to `5`

## Rationale

Increasing the maximum number of open trades allows for greater trading diversification and potentially better risk management across multiple positions.

## Testing

- [x] Configuration file is valid JSON
- [x] No breaking changes to existing functionality

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KWMAV0VS71RCKTT9FWZMF994&panel=chat)